### PR TITLE
Gym 0.25.0 incompatible with d4rl

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages
 setup(
     name='d4rl',
     version='1.1',
-    install_requires=['gym',
+    install_requires=['gym<0.25.0',
                       'numpy',
                       'mujoco_py',
                       'pybullet',

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 from distutils.core import setup
-from platform import platform
 
 from setuptools import find_packages
 
@@ -13,8 +12,7 @@ setup(
                       'h5py',
                       'termcolor',  # adept_envs dependency
                       'click',  # adept_envs dependency
-                      'dm_control' if 'macOS' in platform() else
-                      'dm_control @ git+https://github.com/deepmind/dm_control@main#egg=dm_control',
+                      'dm_control>=1.0.3',
                       'mjrl @ git+https://github.com/aravindr93/mjrl@master#egg=mjrl'],
     packages=find_packages(),
     package_data={'d4rl': ['locomotion/assets/*',


### PR DESCRIPTION
The recent [0.25.0 gym release](https://github.com/openai/gym/releases/tag/0.25.0) introduces returning 5 variables from the `step` function, which d4rl is not updated to handle. This PR enforces `gym<0.25.0` until d4rl is updated. As a bonus, it sets `dm_control>=1.0.3` which is the latest release instead of master which can break downstream installations.