### PR TITLE
Updated Collection.Mapping to  Collection.abc.Mapping

### DIFF
--- a/d4rl/kitchen/adept_envs/mujoco_env.py
+++ b/d4rl/kitchen/adept_envs/mujoco_env.py
@@ -87,7 +87,7 @@ class MujocoEnv(gym.Env):
         try:
             self.action_space = spaces.Box(
                 act_lower, act_upper, dtype=np.float32)
-            if isinstance(observation, collections.Mapping):
+            if isinstance(observation, collections.abc.Mapping):
                 self.observation_space = spaces.Dict({
                 k: spaces.Box(-np.inf, np.inf, shape=v.shape, dtype=np.float32) for k, v in observation.items()})
             else:
@@ -98,7 +98,7 @@ class MujocoEnv(gym.Env):
         except TypeError:
             # Fallback case for gym 0.9.x
             self.action_space = spaces.Box(act_lower, act_upper)
-            assert not isinstance(observation, collections.Mapping), 'gym 0.9.x does not support dictionary observation.'
+            assert not isinstance(observation, collections.abc.Mapping), 'gym 0.9.x does not support dictionary observation.'
             self.obs_dim = np.sum([o.size for o in observation]) if type(observation) is tuple else observation.size
             self.observation_space = spaces.Box(
                 -np.inf, np.inf, observation.shape)


### PR DESCRIPTION
# Description
Collection.Mapping deprecated for python +3.10
When trying to use kitchen environments with a python version +3.10 ,  collection.Mapping throws an error as it is now deprecated. 

Fixes # (issue)
Changing this to collection.abc.Mapping.  This is backwards compatible with all  Python >= 3.3

## Type of change
-  Bug fix (non-breaking change which fixes an issue)
