### PR TITLE
Remove unused rendering from Kitchen Environments.

### DIFF
--- a/d4rl/kitchen/adept_envs/franka/kitchen_multitask_v0.py
+++ b/d4rl/kitchen/adept_envs/franka/kitchen_multitask_v0.py
@@ -110,7 +110,7 @@ class KitchenV0(robot_env.RobotEnv):
             'obs_dict': self.obs_dict,
             'rewards': reward_dict,
             'score': score,
-            'images': np.asarray(self.render(mode='rgb_array'))
+            # 'images': np.asarray(self.render(mode='rgb_array'))
         }
         # self.render()
         return obs, reward_dict['r_total'], done, env_info


### PR DESCRIPTION
# Description

By default the Franka Kitchen environments render very large images, which are not used by policies. This makes running evaluation with the gym API much slower than it needs to be. Simply commenting out this line makes everything much faster.

Fixes evaluation speed for Franka Kitchen environments

## Type of change
 Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
