### PR TITLE
Fix the bug in D4RL that the seed parameter is ignored.

### DIFF
--- a/d4rl/locomotion/ant.py
+++ b/d4rl/locomotion/ant.py
@@ -205,7 +205,6 @@ class AntMazeEnv(maze_env.MazeEnv, GoalReachingAntEnv, offline_env.OfflineEnv):
     return self.set_target_goal(target_location)
 
   def seed(self, seed=None):
-    # print(f"MazeEnv seed = {seed}")
     mujoco_env.MujocoEnv.seed(self, seed)
 
 def make_ant_maze_env(**kwargs):

--- a/d4rl/locomotion/ant.py
+++ b/d4rl/locomotion/ant.py
@@ -184,22 +184,21 @@ class AntMazeEnv(maze_env.MazeEnv, GoalReachingAntEnv, offline_env.OfflineEnv):
     self.v2_resets = v2_resets
           
   def reset(self):
-    # if self.v2_resets:
-    #   """
-    #   The target goal for evaluation in antmazes is randomized.
-    #   antmazes-v0 and -v1 resulted in really high-variance evaluations
-    #   because the target goal was set once at the seed level. This led to
-    #   each run running evaluations with one particular goal. To accurately
-    #   cover each goal, this requires about 50-100 seeds, which might be
-    #   computationally infeasible. As an alternate fix, to reduce variance 
-    #   in result reporting, we are creating the v2 environments
-    #   which use the same offline dataset as v0 environments, with the distinction 
-    #   that the randomization of goals during evaluation is performed at the level of
-    #   each rollout. Thus running a few seeds, but performing the final evaluation 
-    #   over 100-200 episodes will give a valid estimate of an algorithm's performance.
-    #   """      
-    #   self.set_target()
-    self.set_target()
+    if self.v2_resets:
+      """
+      The target goal for evaluation in antmazes is randomized.
+      antmazes-v0 and -v1 resulted in really high-variance evaluations
+      because the target goal was set once at the seed level. This led to
+      each run running evaluations with one particular goal. To accurately
+      cover each goal, this requires about 50-100 seeds, which might be
+      computationally infeasible. As an alternate fix, to reduce variance 
+      in result reporting, we are creating the v2 environments
+      which use the same offline dataset as v0 environments, with the distinction 
+      that the randomization of goals during evaluation is performed at the level of
+      each rollout. Thus running a few seeds, but performing the final evaluation 
+      over 100-200 episodes will give a valid estimate of an algorithm's performance.
+      """      
+      self.set_target()
     return super().reset()
     
   def set_target(self, target_location=None):

--- a/d4rl/locomotion/ant.py
+++ b/d4rl/locomotion/ant.py
@@ -184,28 +184,30 @@ class AntMazeEnv(maze_env.MazeEnv, GoalReachingAntEnv, offline_env.OfflineEnv):
     self.v2_resets = v2_resets
           
   def reset(self):
-    if self.v2_resets:
-      """
-      The target goal for evaluation in antmazes is randomized.
-      antmazes-v0 and -v1 resulted in really high-variance evaluations
-      because the target goal was set once at the seed level. This led to
-      each run running evaluations with one particular goal. To accurately
-      cover each goal, this requires about 50-100 seeds, which might be
-      computationally infeasible. As an alternate fix, to reduce variance 
-      in result reporting, we are creating the v2 environments
-      which use the same offline dataset as v0 environments, with the distinction 
-      that the randomization of goals during evaluation is performed at the level of
-      each rollout. Thus running a few seeds, but performing the final evaluation 
-      over 100-200 episodes will give a valid estimate of an algorithm's performance.
-      """      
-      self.set_target()
+    # if self.v2_resets:
+    #   """
+    #   The target goal for evaluation in antmazes is randomized.
+    #   antmazes-v0 and -v1 resulted in really high-variance evaluations
+    #   because the target goal was set once at the seed level. This led to
+    #   each run running evaluations with one particular goal. To accurately
+    #   cover each goal, this requires about 50-100 seeds, which might be
+    #   computationally infeasible. As an alternate fix, to reduce variance 
+    #   in result reporting, we are creating the v2 environments
+    #   which use the same offline dataset as v0 environments, with the distinction 
+    #   that the randomization of goals during evaluation is performed at the level of
+    #   each rollout. Thus running a few seeds, but performing the final evaluation 
+    #   over 100-200 episodes will give a valid estimate of an algorithm's performance.
+    #   """      
+    #   self.set_target()
+    self.set_target()
     return super().reset()
     
   def set_target(self, target_location=None):
     return self.set_target_goal(target_location)
 
-  def seed(self, seed=0):
-      mujoco_env.MujocoEnv.seed(self, seed)
+  def seed(self, seed=None):
+    # print(f"MazeEnv seed = {seed}")
+    mujoco_env.MujocoEnv.seed(self, seed)
 
 def make_ant_maze_env(**kwargs):
   env = AntMazeEnv(**kwargs)

--- a/d4rl/locomotion/maze_env.py
+++ b/d4rl/locomotion/maze_env.py
@@ -214,13 +214,13 @@ class MazeEnv(gym.Env):
   def _get_reset_location(self,):
     prob = (1.0 - self._np_maze_map) / np.sum(1.0 - self._np_maze_map) 
     prob_row = np.sum(prob, 1)
-    row_sample = np.random.choice(np.arange(self._np_maze_map.shape[0]), p=prob_row)
-    col_sample = np.random.choice(np.arange(self._np_maze_map.shape[1]), p=prob[row_sample] * 1.0 / prob_row[row_sample])
+    row_sample = self.np_random.choice(np.arange(self._np_maze_map.shape[0]), p=prob_row)
+    col_sample = self.np_random.choice(np.arange(self._np_maze_map.shape[1]), p=prob[row_sample] * 1.0 / prob_row[row_sample])
     reset_location = self._rowcol_to_xy((row_sample, col_sample))
     
     # Add some random noise
-    random_x = np.random.uniform(low=0, high=0.5) * 0.5 * self._maze_size_scaling
-    random_y = np.random.uniform(low=0, high=0.5) * 0.5 * self._maze_size_scaling
+    random_x = self.np_random.uniform(low=0, high=0.5) * 0.5 * self._maze_size_scaling
+    random_y = self.np_random.uniform(low=0, high=0.5) * 0.5 * self._maze_size_scaling
 
     return (max(reset_location[0] + random_x, 0), max(reset_location[1] + random_y, 0))
 
@@ -229,8 +229,8 @@ class MazeEnv(gym.Env):
     x = col * self._maze_size_scaling - self._init_torso_x
     y = row * self._maze_size_scaling - self._init_torso_y
     if add_random_noise:
-      x = x + np.random.uniform(low=0, high=self._maze_size_scaling * 0.25)
-      y = y + np.random.uniform(low=0, high=self._maze_size_scaling * 0.25)
+      x = x + self.np_random.uniform(low=0, high=self._maze_size_scaling * 0.25)
+      y = y + self.np_random.uniform(low=0, high=self._maze_size_scaling * 0.25)
     return (x, y)
 
   def goal_sampler(self, np_random, only_free_cells=True, interpolate=True):
@@ -247,11 +247,11 @@ class MazeEnv(gym.Env):
     # If there is a 'goal' designated, use that. Otherwise, any valid cell can
     # be a goal.
     sample_choices = goal_cells if goal_cells else valid_cells
-    cell = sample_choices[np_random.choice(len(sample_choices))]
+    cell = sample_choices[self.np_random.choice(len(sample_choices))]
     xy = self._rowcol_to_xy(cell, add_random_noise=True)
 
-    random_x = np.random.uniform(low=0, high=0.5) * 0.25 * self._maze_size_scaling
-    random_y = np.random.uniform(low=0, high=0.5) * 0.25 * self._maze_size_scaling
+    random_x = self.np_random.uniform(low=0, high=0.5) * 0.25 * self._maze_size_scaling
+    random_y = self.np_random.uniform(low=0, high=0.5) * 0.25 * self._maze_size_scaling
 
     xy = (max(xy[0] + random_x, 0), max(xy[1] + random_y, 0))
 
@@ -259,7 +259,7 @@ class MazeEnv(gym.Env):
   
   def set_target_goal(self, goal_input=None):
     if goal_input is None:
-      self.target_goal = self.goal_sampler(np.random)
+      self.target_goal = self.goal_sampler(self.np_random)
     else:
       self.target_goal = goal_input
     

--- a/d4rl/locomotion/wrappers.py
+++ b/d4rl/locomotion/wrappers.py
@@ -22,6 +22,9 @@ class ProxyEnv(Env):
 
     def step(self, action):
         return self._wrapped_env.step(action)
+    
+    def seed(self, seed=None):
+        return self._wrapped_env.seed(seed)
 
     def render(self, *args, **kwargs):
         return self._wrapped_env.render(*args, **kwargs)


### PR DESCRIPTION
# Description

Fix the bug in D4RL that the seed parameter is ignored.
- The seed was fixed for AntMaze environments due to [this](https://github.com/Farama-Foundation/D4RL/blob/71a9549f2091accff93eeff68f1f3ab2c0e0a288/d4rl/locomotion/ant.py#L207), causing the seed parameter to be ignored when executing `env.seed(seed=seed)`. By adding the two lines in `d4rl/locomotion/wrappers.py`, calling `env.seed(seed=seed)` will effectively assign the specified seed to the environment.
- For reproducibility, the `np.random` is replaced by `self.np_random` in `d4rl/locomotion/maze_env.py`. The `self.goal_sampler()` retuens a randomly sampled goal position. However, if using `np.random`, this sample process is not controlled by the seed we set, causing inconsistency in results.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)



<!--
Example:

| Before | After |
| ------ | ----- |
| _gif/png before_ | _gif/png after_ |


To upload images to a PR -- simply drag and drop an image while in edit mode, and it should upload the image directly. 
You can then paste that source into the above before/after sections.
-->

# Checklist:

- [ ] I have run the [`pre-commit` checks](https://pre-commit.com/) with `pre-commit run --all-files` (see `CONTRIBUTING.md` instructions to set it up)
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

<!--
As you go through the checklist above, you can mark something as done by putting an x character in it

For example,
- [x] I have done this task
- [ ] I have not done this task
-->
