### PR TITLE
Allow higher python versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ setup(
     long_description=long_description,
     long_description_content_type="text/markdown",
     keywords=["Reinforcement Learning", "Datasets", "RL", "AI"],
-    python_requires=">=3.7, <3.11",
+    python_requires=">=3.7",
     packages=find_packages(),
     include_package_data=True,
     package_data={


### PR DESCRIPTION
# Description

The build on pip install and a basic test of getting a dataset for an environment were successful.

Fixes #233

Logically this will allow people to try installing on whatever higher python they have. This might succeed. Or they will come back with specific issues in the repo. Current state of forbidding out of principle higher versions seems not helpful, or am I using some usecase?
